### PR TITLE
Bind Escape to hide translation window

### DIFF
--- a/translator_app.py
+++ b/translator_app.py
@@ -121,10 +121,17 @@ class TranslationWindowManager:
         def hide_window() -> None:
             window.withdraw()
 
+        def handle_escape(event: tk.Event) -> str:
+            """Hide the window when the Escape key is pressed."""
+
+            hide_window()
+            return "break"
+
         close_button = tk.Button(window, text="Close", command=hide_window)
         close_button.pack(pady=(0, 10))
 
         window.protocol("WM_DELETE_WINDOW", hide_window)
+        window.bind("<Escape>", handle_escape)
 
         def _monitor_work_area(pointer_x: int, pointer_y: int) -> tuple[int, int, int, int] | None:
             """Return work area bounds for the monitor nearest the pointer."""


### PR DESCRIPTION
## Summary
- add an Escape key binding to the translation window
- hide the window when Escape is pressed to mirror the Close button behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a4da611c8321b647d9e8ea403bb7