### PR TITLE
Build Windows executable without console window

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ python -m unittest discover
    python packaging/build_executable.py
    ```
 
-スクリプトは `package` ディレクトリを作成し、その中に `CCTranslationTool.exe` を出力します。PyInstaller が生成する一時的な `build/` や `dist/` ディレクトリ、`.spec` ファイルは自動的に削除されます。
+スクリプトは `package` ディレクトリを作成し、その中に `CCTranslationTool.exe` を出力します。生成される実行ファイルはコンソールウィンドウを表示せずにバックグラウンドで起動します。PyInstaller が生成する一時的な `build/` や `dist/` ディレクトリ、`.spec` ファイルは自動的に削除されます。

--- a/packaging/build_executable.py
+++ b/packaging/build_executable.py
@@ -49,6 +49,7 @@ def build() -> Path:
         "PyInstaller",
         "--clean",
         "--noconfirm",
+        "--noconsole",
         "--onefile",
         "--name",
         EXECUTABLE_NAME.replace(".exe", ""),


### PR DESCRIPTION
## Summary
- add PyInstaller's --noconsole flag so the packaged EXE runs without a console window
- document that the generated executable launches in the background without displaying a console

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d7a8d7d9148321846ed5eac829a1f3