### PR TITLE
Add system tray exit control for Windows executable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 keyboard>=0.13.5
 pyperclip>=1.8.2
+pystray>=0.19.4
+Pillow>=9.0.0

--- a/tests/test_translator_app.py
+++ b/tests/test_translator_app.py
@@ -126,6 +126,12 @@ class CCTranslationAppTests(unittest.TestCase):
         self.assertIn("Error during translation", captured[0][1])
         self.assertEqual(captured[0][2], "en")
 
+    def test_stop_sets_event(self):
+        app = self._create_app()
+        self.assertFalse(app._stop_event.is_set())
+        app.stop()
+        self.assertTrue(app._stop_event.is_set())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a Windows system tray controller so the executable can be stopped from the hidden indicator
- update the application lifecycle to use a stop event and expose a stop method for external shutdown requests
- expand unit coverage for the new stop flow and declare the additional runtime dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7af13c0ec83219f36e6668f710f68