### PR TITLE
Handle stop event during CCTranslationApp reboot

### DIFF
--- a/tests/test_translator_app.py
+++ b/tests/test_translator_app.py
@@ -1,6 +1,7 @@
 import io
 import queue
 import sys
+import threading
 import types
 import unittest
 import unittest.mock as mock
@@ -83,7 +84,7 @@ class ErroringTranslator:
         raise TranslationError("boom")
 
 
-class CCTranslationAppTests(unittest.TestCase):
+class CCTranslationAppTestMixin:
     def _create_app(self, **overrides) -> CCTranslationApp:
         fake_time = overrides.pop("fake_time", None)
         if fake_time is None:
@@ -103,6 +104,8 @@ class CCTranslationAppTests(unittest.TestCase):
         app._fake_time = fake_time
         return app
 
+
+class CCTranslationAppTests(CCTranslationAppTestMixin, unittest.TestCase):
     def test_single_copy_does_not_enqueue(self):
         app = self._create_app()
         app._handle_copy_event()
@@ -226,6 +229,42 @@ class CCTranslationAppTests(unittest.TestCase):
 
         request = app._request_queue.get_nowait()
         self.assertEqual(request.text, "hello")
+
+
+class CCTranslationAppLifecycleTests(CCTranslationAppTestMixin, unittest.TestCase):
+    def test_stop_after_reboot_exits_start_loop(self):
+        app = self._create_app()
+
+        ready = threading.Event()
+
+        class FakeTrayController:
+            def __init__(self) -> None:
+                self.start_calls = 0
+                self.stop_calls = 0
+
+            def start(self) -> None:
+                self.start_calls += 1
+                ready.set()
+
+            def stop(self) -> None:
+                self.stop_calls += 1
+
+        tray = FakeTrayController()
+
+        thread = threading.Thread(target=lambda: app.start(tray_controller=tray))
+        thread.start()
+        try:
+            self.assertTrue(ready.wait(timeout=1), "App did not reach running state in time")
+
+            ready.clear()
+            app.reboot()
+            app.stop()
+
+            thread.join(timeout=1)
+            self.assertFalse(thread.is_alive(), "App should exit after stop following reboot")
+        finally:
+            app.stop()
+            thread.join(timeout=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- restructure `CCTranslationApp.start` to reuse the worker thread, honor stop events, and clear the stop flag only when a restart is requested
- add a regression test covering a reboot immediately followed by stop to ensure the start loop exits cleanly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d94add0e0083219c1f7a6b52dd4ee5