### PR TITLE
Add reboot option to system tray menu

### DIFF
--- a/tests/test_translator_app.py
+++ b/tests/test_translator_app.py
@@ -31,7 +31,7 @@ if "pystray" not in sys.modules:
     stub_pystray.MenuItem = _StubMenuItem
     sys.modules["pystray"] = stub_pystray
 
-from translator_app import CCTranslationApp, TranslationRequest
+from translator_app import CCTranslationApp, TranslationRequest, SystemTrayController
 from translation_service import TranslationError
 
 
@@ -334,6 +334,32 @@ class CCTranslationAppLifecycleTests(CCTranslationAppTestMixin, unittest.TestCas
         finally:
             app.stop()
             thread.join(timeout=1)
+
+
+class SystemTrayControllerTests(unittest.TestCase):
+    def test_reboot_menu_item_triggers_reboot_and_stops_icon(self) -> None:
+        class DummyApp:
+            def __init__(self) -> None:
+                self.reboot_called = False
+
+            def reboot(self) -> None:
+                self.reboot_called = True
+
+        class DummyIcon:
+            def __init__(self) -> None:
+                self.stopped = False
+
+            def stop(self) -> None:
+                self.stopped = True
+
+        dummy_app = DummyApp()
+        controller = SystemTrayController(dummy_app)
+        icon = DummyIcon()
+
+        controller._on_reboot(icon, None)
+
+        self.assertTrue(dummy_app.reboot_called)
+        self.assertTrue(icon.stopped)
 
 
 if __name__ == "__main__":

--- a/translator_app.py
+++ b/translator_app.py
@@ -565,7 +565,7 @@ class TranslationWindowManager:
 
 
 class SystemTrayController:
-    """Manage a Windows system tray icon with an Exit command."""
+    """Manage a Windows system tray icon with Reboot and Exit commands."""
 
     def __init__(self, app: "CCTranslationApp") -> None:
         self._app = app
@@ -593,7 +593,10 @@ class SystemTrayController:
         assert pystray is not None  # noqa: S101 - guarded by _is_supported
         image = self._create_icon_image()
         self._icon_image = image
-        menu = pystray.Menu(MenuItem("Exit", self._on_exit))
+        menu = pystray.Menu(
+            MenuItem("Reboot", self._on_reboot),
+            MenuItem("Exit", self._on_exit),
+        )
         self._icon = pystray.Icon("cctranslationtool", image, "CCTranslationTool", menu=menu)
         self._icon.run_detached()
 
@@ -605,6 +608,10 @@ class SystemTrayController:
 
     def _on_exit(self, icon: "pystray.Icon", _: MenuItem) -> None:
         self._app.stop()
+        icon.stop()
+
+    def _on_reboot(self, icon: "pystray.Icon", _: MenuItem) -> None:
+        self._app.reboot()
         icon.stop()
 
     def _create_icon_image(self) -> "Image.Image":


### PR DESCRIPTION
## Summary
- add a Reboot menu entry to the system tray controller so the app can restart from the tray icon
- ensure the tray callback invokes the existing reboot logic and stops the tray icon cleanly
- add a unit test to cover the new reboot menu behaviour

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d952b81d4c832195e9875a16a1e42c