### PR TITLE
コピーイベント調査のためのロギングを追加

### DIFF
--- a/keyboard_hook_probe.py
+++ b/keyboard_hook_probe.py
@@ -1,0 +1,100 @@
+"""Utility script to record raw keyboard events using the `keyboard` package.
+
+This helper can be used on the affected Windows machine to verify whether
+low-level keyboard hooks keep receiving events when the main application stops
+reacting to Ctrl+C.  The script prints every event with a timestamp to stdout
+and optionally mirrors it to a log file so the recording can be inspected after
+longer runs.
+
+Usage example::
+
+    python keyboard_hook_probe.py --log keyboard_events.log
+
+Press ``Ctrl+Shift+Q`` or ``Ctrl+C`` to stop the capture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import keyboard
+
+
+def _format_event(event: "keyboard.KeyboardEvent") -> str:
+    timestamp = _dt.datetime.now().isoformat(timespec="milliseconds")
+    return (
+        f"{timestamp} event_type={event.event_type:5s} "
+        f"name={event.name!r:<10} scan_code={event.scan_code:<4d} "
+        f"is_keypad={event.is_keypad} device={event.device!s}"
+    )
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Record raw keyboard events via keyboard.hook(print) to determine "
+            "whether the global hook stops receiving Ctrl+C."
+        )
+    )
+    parser.add_argument(
+        "--log",
+        type=Path,
+        help="Optional file path to append the captured events.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Optional maximum duration in seconds before the script exits.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    log_file = None
+    if args.log is not None:
+        try:
+            log_file = args.log.open("a", encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - depends on filesystem
+            print(f"Failed to open log file {args.log}: {exc}", file=sys.stderr)
+            return 1
+
+    stop_message = (
+        "Recording raw keyboard events. Press Ctrl+Shift+Q or Ctrl+C to stop."
+    )
+    print(stop_message)
+
+    def _handler(event: "keyboard.KeyboardEvent") -> None:
+        line = _format_event(event)
+        print(line, flush=True)
+        if log_file is not None:
+            log_file.write(line + "\n")
+            log_file.flush()
+
+    keyboard.hook(_handler)
+
+    try:
+        if args.duration is not None:
+            deadline = time.time() + max(args.duration, 0)
+            while time.time() < deadline:
+                time.sleep(0.1)
+        else:
+            keyboard.wait("ctrl+shift+q")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        keyboard.unhook_all()
+        if log_file is not None:
+            log_file.close()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility script
+    raise SystemExit(main())

--- a/tests/test_translator_app.py
+++ b/tests/test_translator_app.py
@@ -32,7 +32,13 @@ if "pystray" not in sys.modules:
     stub_pystray.MenuItem = _StubMenuItem
     sys.modules["pystray"] = stub_pystray
 
-from translator_app import CCTranslationApp, TranslationRequest, SystemTrayController
+from translator_app import (
+    CCTranslationApp,
+    TranslationRequest,
+    SystemTrayController,
+    parse_args,
+    print_troubleshooting_guide,
+)
 from translation_service import TranslationError
 
 
@@ -482,6 +488,24 @@ class SystemTrayControllerTests(unittest.TestCase):
 
         self.assertTrue(dummy_app.reboot_called)
         self.assertTrue(icon.stopped)
+
+
+class TroubleshootingGuideTests(unittest.TestCase):
+    def test_troubleshooting_guide_prints_expected_keywords(self) -> None:
+        buffer = io.StringIO()
+        print_troubleshooting_guide(buffer)
+        output = buffer.getvalue()
+        self.assertIn("Ctrl+Shift+H", output)
+        self.assertIn("keyboard_hook_probe.py", output)
+
+    def test_parse_args_exposes_show_debug_guide_flag(self) -> None:
+        original = sys.argv[:]
+        try:
+            sys.argv = ["translator_app.py", "--show-debug-guide"]
+            args = parse_args()
+        finally:
+            sys.argv = original
+        self.assertTrue(args.show_debug_guide)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- DoubleCopyDetector に直近のインターバルやカウントを保持するプロパティを追加
- Ctrl+C ハンドラでホットキー検知状況・ワーカースレッド状態・キュー投入状況を INFO ログ出力
- クリップボードエラー時の WARNING ログと例外捕捉を追加し、main で logging.basicConfig を構成

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da779aa71c8321ab1c2e60ff209d52