### PR TITLE
待機キューを1件に制限して最新依頼のみ保持

### DIFF
--- a/tests/test_translator_app.py
+++ b/tests/test_translator_app.py
@@ -165,6 +165,18 @@ class CCTranslationAppTests(CCTranslationAppTestMixin, unittest.TestCase):
         self.assertEqual(request.dest, "en")
         self.assertFalse(request.reposition)
 
+    def test_waiting_queue_keeps_only_latest_request(self):
+        app = self._create_app()
+
+        app._enqueue_request(TranslationRequest(text="first", src=None, dest="ja"))
+        app._enqueue_request(TranslationRequest(text="second", src="en", dest="ja", reposition=False))
+
+        request = app._request_queue.get_nowait()
+        self.assertEqual(request.text, "second")
+        self.assertEqual(request.src, "en")
+        self.assertFalse(request.reposition)
+        self.assertTrue(app._request_queue.empty())
+
     def test_process_single_request_uses_translator(self):
         translator = FakeTranslator(translated="translated", detected="en")
         captured = []

--- a/translator_app.py
+++ b/translator_app.py
@@ -689,7 +689,7 @@ class CCTranslationApp:
         self._translator_lock = threading.Lock()
         self._copy_detector = DoubleCopyDetector(double_copy_interval, time_provider)
         self._lock = threading.Lock()
-        self._request_queue: "queue.Queue[TranslationRequest]" = queue.Queue()
+        self._request_queue: "queue.Queue[TranslationRequest]" = queue.Queue(maxsize=1)
         self._stop_event = threading.Event()
         self._restart_event = threading.Event()
         self._worker_thread: Optional[threading.Thread] = None
@@ -829,9 +829,20 @@ class CCTranslationApp:
                     return
                 text = text.strip()
                 if text:
-                    self._request_queue.put(
+                    self._enqueue_request(
                         TranslationRequest(text=text, src=self.source_language, dest=self.dest_language)
                     )
+
+    def _enqueue_request(self, request: TranslationRequest) -> None:
+        """Keep only one waiting request so stale work does not accumulate."""
+
+        try:
+            while True:
+                self._request_queue.get_nowait()
+                self._request_queue.task_done()
+        except queue.Empty:
+            pass
+        self._request_queue.put_nowait(request)
 
     def _process_requests(self) -> None:
         while True:
@@ -889,7 +900,7 @@ class CCTranslationApp:
     ) -> None:
         if not text or not dest:
             return
-        self._request_queue.put(
+        self._enqueue_request(
             TranslationRequest(text=text, src=src, dest=dest, reposition=False)
         )
 


### PR DESCRIPTION
### Motivation
- 大気エリア（待機キュー）に複数の翻訳リクエストが滞留すると古い依頼が処理されてしまうため、常に最新の1件だけが待機するようにしたい。 
- 実運用で「大気エリアには常に1台しか待機しない」制約を満たすための変更を行う。

### Description
- `CCTranslationApp` の待機キューを `queue.Queue(maxsize=1)` に変更して同時に待てる件数を1件に制限しました (`translator_app.py`)。 
- 新たに `_enqueue_request` を追加し、投入前に既存の待機リクエストを破棄して最新リクエストのみを保持するロジックを実装しました (`translator_app.py`)。 
- ダブルコピー時の投入 (`_handle_copy_event`) と再翻訳投入 (`_enqueue_retranslation`) を `_enqueue_request` 経由で行うように統一しました (`translator_app.py`)。 
- 最新1件のみが残ることを確認するユニットテスト `test_waiting_queue_keeps_only_latest_request` を `tests/test_translator_app.py` に追加しました。 

### Testing
- `python -m unittest discover` を実行し、全テストが成功しました（15 tests, OK）。
- 追加したテスト `CCTranslationAppTests::test_waiting_queue_keeps_only_latest_request` を含む全テストが通っています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a302c0d5e88321b5aa4139a1945e74)